### PR TITLE
docker-compose.yaml 增加restart参数，启动失败后自动重启

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     container_name: "frontend"
     depends_on:
       - atomci
+    restart: always
     networks:
         - atomci-network
     ports:
@@ -18,6 +19,7 @@ services:
     container_name: "atomci"
     depends_on:
       - mysql
+    restart: always
     networks:
       - atomci-network
     ports:


### PR DESCRIPTION
部署或者重启时

1. atomci会因为mysql数据库未启动完成导致运行失败，
2. frontend会因为atomci挂掉而连带失败

在docker-compose.yaml中增加restart：always参数 使用失败重启的方案来实现应用正常启动