### PR TITLE
fix: pub detail log title is empty

### DIFF
--- a/web/src/router/modules/projectDetailRouter.js
+++ b/web/src/router/modules/projectDetailRouter.js
@@ -65,8 +65,8 @@ export function projectDetailRouter() {
         },
         {
           path: '/project/projectPubDetail/:projectID/:jobName/:runId/:stageId',
-          rename: '发布详情',
           name: 'projectPubDetail',
+          meta: { title: '日志详情', noCache: true },
           component: () => import('@/views/project/detail/ProjectPubDetail.vue'),
           hidden: true
         },


### PR DESCRIPTION
### Which changes (Bug/Feature):
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes pub detail log title is empty

### Special notes for reviewers:

![image](https://user-images.githubusercontent.com/5203608/147562214-169cc378-a983-4f78-87b2-ca44470fa0a1.png)

