### PR TITLE
feat: #135 支持代码源仓库地址联通性检测

### DIFF
--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -43,6 +43,22 @@ func (a *AppController) CreateSCMApp() {
 	a.ServeJSON()
 }
 
+// VerifySCMAppConnetion
+// 验证仓库地址是否能连通
+func (a *AppController) VerifySCMAppConnetion() {
+	req := &apps.ScmAppReq{}
+	a.DecodeJSONReq(&req)
+	app := apps.NewAppManager()
+	err := app.VerifyAppConnetion(req.RepoID, req.Path, req.FullName)
+	if err != nil {
+		a.HandleInternalServerError(err.Error())
+		log.Log.Error("verify scm app connetion occur error: %s", err.Error())
+		return
+	}
+	a.Data["json"] = NewResult(true, "", "")
+	a.ServeJSON()
+}
+
 func (a *AppController) GetAllApps() {
 	mgr := apps.NewAppManager()
 	// TODO: add app tag filter base on permisson

--- a/internal/routers/router.go
+++ b/internal/routers/router.go
@@ -85,6 +85,7 @@ func RegisterRoutes() {
 				beego.NSRouter("/integrate/settings/scms", &api.IntegrateController{}, "get:GetSCMIntegrateSettings;post:GetSCMIntegrateSettingsByPagination"),
 				beego.NSRouter("/integrate/settings/:id", &api.IntegrateController{}, "put:UpdateIntegrateSetting;delete:DeleteIntegrateSetting"),
 				beego.NSRouter("/integrate/settings/verify", &api.IntegrateController{}, "post:VerifyIntegrateSetting"),
+				beego.NSRouter("/integrate/settings/verifyrepo", &api.IntegrateController{}, "post:VerifyRepoConnetion"),
 				beego.NSRouter("/integrate/clusters", &api.IntegrateController{}, "get:GetClusterIntegrateSettings"),
 				// CompileEnv
 				beego.NSRouter("/integrate/compile_envs", &api.IntegrateController{}, "get:GetCompileEnvs;post:GetCompileEnvsByPagination"),
@@ -94,6 +95,7 @@ func RegisterRoutes() {
 				// scm apps
 				beego.NSRouter("/repos/:repo_id/projects", &api.AppController{}, "post:GetGitProjectsByRepoID"),
 				beego.NSRouter("/apps/create", &api.AppController{}, "post:CreateSCMApp"),
+				beego.NSRouter("/apps/verifyapp", &api.AppController{}, "post:VerifySCMAppConnetion"),
 				beego.NSRouter("/apps", &api.AppController{}, "get:GetAllApps;post:GetAppsByPagination"),
 				beego.NSRouter("/apps/:app_id", &api.AppController{}, "get:ScmAppInfo;put:UpdateScmApp;delete:DeleteScmApp"),
 				beego.NSRouter("/apps/:app_id/syncBranches", &api.AppController{}, "post:SyncAppBranches"),

--- a/web/src/api/backend.js
+++ b/web/src/api/backend.js
@@ -722,6 +722,10 @@ const backendAPI = {
   editIntegrateSetting(idStep, body, cb) {
     Package.httpMethods('put', `/atomci/api/v1/integrate/settings/${idStep}`, cb, body);
   },
+  // 验证仓库源是否联通
+  verifyRepoConnetion(body, cb) {
+    Package.httpMethods('post', `/atomci/api/v1/integrate/settings/verifyrepo`, cb, body);
+  },
   delIntegrateSetting(idStep, cb) {
     Package.httpMethods('delete', `/atomci/api/v1/integrate/settings/${idStep}`, cb);
   },
@@ -907,6 +911,10 @@ const backendAPI = {
   //新增
   addScmAppPro(body, cb) {
     Package.httpMethods('post', `/atomci/api/v1/apps/create`, cb, body);
+  },
+  // 验证应用地址是否能正常联通
+  verifyAppConnetion(body, cb) {
+    Package.httpMethods('post', `/atomci/api/v1/apps/verifyapp`, cb, body);
   },
   //应用编排
   getProjectArrange(project_id, app_id, arrange_env, cb) {

--- a/web/src/views/scmapp/components/AppAdd.vue
+++ b/web/src/views/scmapp/components/AppAdd.vue
@@ -129,6 +129,7 @@
         </el-form>
       </template>
         <div class="apparrange-layout">
+          <el-button type="success" @click="doTestConnection" :loading="loading">测试连接</el-button>
           <el-button
             type="primary"
             class="fb-ly-rbtn"
@@ -285,22 +286,44 @@ export default {
         })
         .catch((_) => {});
     },
-    addApp() {
-      this.$refs.ruleForm.validate((valid) => {
-        if (valid) {
-          // 完整的路径地址不存在的话，则组装一个出来
-          if(this.form.path==""){
-            for (let i = 0; i < this.integrateRepos.length; i++) {
-              if (this.integrateRepos[i].id == this.form.repo_id) {
-                let domain= this.integrateRepos[i].config.url;
-                if(domain && domain.length>0 && domain.substring(domain.length-1)=='/'){
-                  this.form.path = domain + this.form.full_name + '.git';
-                }else {
-                  this.form.path = domain + '/' + this.form.full_name + '.git';
-                }
+    doTestConnection() {
+      this.setFormPath();
+      const cl = {
+          full_name: this.form.full_name,
+          path: this.form.path,
+          repo_id: this.form.repo_id,
+        };
+      if ( !cl.repo_id ){
+        Message.error("请先选择一个代码源");
+        return;
+      }
+      if ( !cl.full_name || !cl.path){
+        Message.error("请先选择或输入仓库路径");
+        return;
+      }
+      backend.verifyAppConnetion(cl, () => {
+        Message.success("源码仓库地址连接成功");
+      });
+    },
+    setFormPath(){
+        // 完整的路径地址不存在的话，则组装一个出来
+        if(this.form.path==""){
+          for (let i = 0; i < this.integrateRepos.length; i++) {
+            if (this.integrateRepos[i].id == this.form.repo_id) {
+              let domain= this.integrateRepos[i].config.url;
+              if(domain && domain.length>0 && domain.substring(domain.length-1)=='/'){
+                this.form.path = domain + this.form.full_name + '.git';
+              }else {
+                this.form.path = domain + '/' + this.form.full_name + '.git';
               }
             }
           }
+        }
+    },
+    addApp() {
+      this.$refs.ruleForm.validate((valid) => {
+        if (valid) {
+          this.setFormPath();
           const cl = this.form
           cl.type = 'app';
           cl.dockerfile = this.form.dockerfile || 'Dockerfile';

--- a/web/src/views/setting/components/ScmIntegrateCreate.vue
+++ b/web/src/views/setting/components/ScmIntegrateCreate.vue
@@ -181,7 +181,13 @@ export default {
       this.isEdit = flag;
     },
     doTestConnection() {
-      Message.info('comming soon');
+      const cl = {
+          config: this.form.config,
+          type: this.form.type,
+        };
+      backend.verifyRepoConnetion(cl, () => {
+        Message.success("源码仓库地址连接成功");
+      });
     },
     doSubmit() {
       this.$refs.ruleForm.validate((valid) => {


### PR DESCRIPTION
### Which changes (Bug/Feature):
Fixes #135 
1. 实现【代码源】的【测试连接】按钮
2. 创建应用增加【测试连接】按钮

### Special notes for reviewers:

1. 代码源检测：通过获取机构列表检查。若是无token，返回401也认为地址正确。
2. 应用地址检测：通过获取分支接口进行检查。返回404，则表示路径错误或没有权限。
